### PR TITLE
COPY FROM STDIN support

### DIFF
--- a/apgdiff/antlr-src/SQLLexer.g4
+++ b/apgdiff/antlr-src/SQLLexer.g4
@@ -796,6 +796,7 @@ LESS_LESS : '<<';
 GREATER_GREATER : '>>';
 DOUBLE_DOT: '..';
 HASH_SIGN: '#';              // last operator rule, sync with CustomSQLAntlrErrorStrategy
+END_OF_DATA: '\\.';
 
 BlockComment
     :   '/*' .*? '*/' -> channel(HIDDEN)
@@ -911,6 +912,12 @@ Extended_Control_Characters         :   '\u0080' .. '\u009F';
 
 Character_String_Literal
     : [eEnN]? Single_String (String_Joiner Single_String)*
+    ;
+
+Copy_Data_Row
+    : StrictIdentifierChar
+    (StrictIdentifierChar | Tab | Space | Single_String | '\\N' | '\\0' | '-' | ':' | '.' | '@' | HEX_DIGIT)*
+    New_Line
     ;
 
 fragment

--- a/apgdiff/antlr-src/SQLParser.g4
+++ b/apgdiff/antlr-src/SQLParser.g4
@@ -1396,9 +1396,15 @@ copy_statement
 
 copy_from_statement
     : COPY table_cols
-    FROM (PROGRAM? Character_String_Literal | STDIN) 
+    FROM PROGRAM? Character_String_Literal
     (WITH? (LEFT_PAREN copy_option_list RIGHT_PAREN | copy_option_list))?
     (WHERE vex)?
+    | COPY table_cols FROM STDIN SEMI_COLON copy_from_stdin_data?
+    ;
+
+copy_from_stdin_data
+    : Copy_Data_Row+
+    END_OF_DATA
     ;
 
 copy_to_statement


### PR DESCRIPTION
Added missing support of parsing COPY FROM STDIN data:
```
COPY users (id, login, password) FROM stdin;
1	john	doe
2	\N	nothing
\.
```
Every data row is parsed as a Copy_Data_Row token. Still need some tests though - I just needed a quick & dirty solution.