### PR TITLE
#82 replaced class.getResource(name) method call with class.getResourceAsStream(name)

### DIFF
--- a/apgdiff/src/main/java/cz/startnet/utils/pgdiff/schema/meta/MetaStorage.java
+++ b/apgdiff/src/main/java/cz/startnet/utils/pgdiff/schema/meta/MetaStorage.java
@@ -1,18 +1,15 @@
 package cz.startnet.utils.pgdiff.schema.meta;
 
-import java.io.IOException;
+import cz.startnet.utils.pgdiff.loader.SupportedVersion;
+import ru.taximaxim.codekeeper.apgdiff.ApgdiffUtils;
+
+import java.io.InputStream;
 import java.io.Serializable;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import cz.startnet.utils.pgdiff.loader.SupportedVersion;
-import ru.taximaxim.codekeeper.apgdiff.ApgdiffUtils;
-import ru.taximaxim.codekeeper.apgdiff.log.Log;
 
 public class MetaStorage implements Serializable {
 
@@ -45,21 +42,14 @@ public class MetaStorage implements Serializable {
         if (db != null) {
             return db;
         }
-
-        try {
-            Path path = ApgdiffUtils.getFileFromOsgiRes(MetaStorage.class.getResource(
-                    FILE_NAME + version + ".ser"));
-            Object object = ApgdiffUtils.deserialize(path);
-
-            if (object instanceof MetaStorage) {
-                MetaStorage storage = (MetaStorage) object;
-                MetaStorage other = STORAGE_CACHE.putIfAbsent(version, storage);
-                return other == null ? storage : other;
-            }
-        } catch (URISyntaxException | IOException e) {
-            Log.log(Log.LOG_ERROR, "Error while reading systems objects from resources");
+        InputStream inputStream = MetaStorage.class.getResourceAsStream(
+                FILE_NAME + version + ".ser");
+        Object object = ApgdiffUtils.deserialize(inputStream);
+        if (object instanceof MetaStorage) {
+            MetaStorage storage = (MetaStorage) object;
+            MetaStorage other = STORAGE_CACHE.putIfAbsent(version, storage);
+            return other == null ? storage : other;
         }
-
         return null;
     }
 }

--- a/apgdiff/src/main/java/ru/taximaxim/codekeeper/apgdiff/ApgdiffUtils.java
+++ b/apgdiff/src/main/java/ru/taximaxim/codekeeper/apgdiff/ApgdiffUtils.java
@@ -1,19 +1,15 @@
 package ru.taximaxim.codekeeper.apgdiff;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.URIUtil;
+import ru.taximaxim.codekeeper.apgdiff.log.Log;
+
+import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.URIUtil;
-
-import ru.taximaxim.codekeeper.apgdiff.log.Log;
 
 public final class ApgdiffUtils {
 
@@ -69,6 +65,18 @@ public final class ApgdiffUtils {
             Log.log(Log.LOG_DEBUG, "Error while deserialize object!", e);
         }
 
+        return null;
+    }
+
+    public static Object deserialize(InputStream inputStream) {
+        if(inputStream == null){
+            return null;
+        }
+        try (ObjectInputStream oin = new ObjectInputStream(inputStream)) {
+            return oin.readObject();
+        } catch (ClassNotFoundException | IOException e) {
+            e.printStackTrace();
+        }
         return null;
     }
 


### PR DESCRIPTION
replaced class.getResource(name) method call with class.getResourceAsStream(name). So that it can search for files within the jar also when we use this as a dependent library in another java program.